### PR TITLE
Remove kubectl test command 

### DIFF
--- a/kubernetes/install-master.sh
+++ b/kubernetes/install-master.sh
@@ -136,12 +136,6 @@ case "$lsb_dist" in
       $sh_c 'apt-get install -y -q kubernetes-master;'
 
     )
-    if command_exists kubectl; then
-      (
-        set -x
-        $sh_c 'kubectl version'
-      ) || true
-    fi
 
     echo
     exit 0


### PR DESCRIPTION
Removing the kubectl version command from the get.kismatic.io install scripts as referenced in #3 