### PR TITLE
Update Kubernetes to v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,34 @@ Nodes: `sudo yum kubernetes-node`
 To configure services, edit configuration files in `/etc/kubernetes/master` or `/etc/kubernetes/node`
 To override services, copy `/lib/systemd/system` to `/etc/systemd/system` to override. This allows you to customize local services without worrying about losing changes as the result of a package upgrade.
 
+*Enable HTTPS (optional)*
+By default, the apiserver is setup using insecure http and assumes a firewall will provide enough security. To enable https support, certs must be generated. A basic key has already been generated during install at `/srv/kubernetes/server.key`. To generate certs:
+```
+cd /srv/kubernetes
+curl -O -L https://raw.githubusercontent.com/kubernetes/kubernetes/v1.1.2/cluster/saltbase/salt/generate-cert/make-ca-cert.sh
+chmod +x make-ca-cert.sh
+
+#Set to your master ip and already chosen cluster ip range
+master_ip=127.0.0.1
+SERVICE_CLUSTER_IP_RANGE=10.254.0.0/16
+
+#Assumes cluster is named 'kubernetes' for DNS
+./make-ca-cert.sh ${master_ip} IP:${master_ip},IP:${SERVICE_CLUSTER_IP_RANGE%.*}.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local;
+```
+
+For AWS the external IP can be automatically discovered using:
+```
+./make-ca-cert.sh _use_aws_external_ip_ (other args...)
+```
+
+Update the kubernetes configuration files with the newly generated keys
+```
+#kube-apiserver
+--secure-port=443 --tls-cert-file=/srv/kubernetes/server.cert --tls-private-key-file=/srv/kubernetes/server.key --client-ca-file=/srv/kubernetes/ca.crt
+
+#kube-controller-manager
+  --root-ca-file=/srv/kubernetes/ca.crt --service-account-private-key-file=/srv/kubernetes/server.key
+```
 
 *Start services*
 sudo systemctl start kube-apiserver
@@ -63,6 +91,7 @@ Install docker on [Ubuntu](https://docs.docker.com/installation/ubuntulinux/) or
 
 #### Configure Kubernetes
 To configure services, edit the file with the same name in `/etc/default`
+
 
 Master
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ While the concepts and architecture in Kubernetes represent years of experience 
 * Kubernetes master:
 ```
 curl -sSL https://get.kismatic.com/kubernetes/master.sh | sudo sh
-`
+```
+
 * Kubernetes nodes:
 ```
 curl -sSL https://get.kismatic.com/kubernetes/node.sh | sudo sh
@@ -19,12 +20,17 @@ curl -sSL https://get.kismatic.com/kubernetes/node.sh | sudo sh
   * Install [etcd](https://github.com/coreos/etcd) (on master or a separate etcd cluster)
   * Install [docker](https://docs.docker.com/installation) (ubuntu/debian only)
 
+## Configuration and Manual Setup
 
-##Configuration and Manual Setup
 ### System.d and RedHat 7 / CentOS 7 Configuration
-`rpm -Uvh https://repos.kismatic.com/el/7/x86_64/kismatic-repo-el-7-1.x86_64.rpm`
-Master: `sudo yum install kubernetes-master`
-Nodes: `sudo yum kubernetes-node`
+
+The quick start scripts above will automatically add the kismatic repository as a source. Alternatively, you can manually add it with the command:
+```
+rpm -Uvh https://repos.kismatic.com/el/7/x86_64/kismatic-repo-el-7-1.x86_64.rpm
+```
+
+Manually Install Master: `sudo yum install kubernetes-master`
+Manually Install Nodes: `sudo yum kubernetes-node`
 
 #### Configure Kubernetes Master
 
@@ -112,36 +118,36 @@ sudo service kubelet start
 
 ## Development Build Notes
 * Make sure to have fpm installed along with rpmbuild
-* run `K8S_VERSION=0.20.2 ./build_kubernetes.sh`
+* run `K8S_VERSION=1.1.2 ./build_kubernetes.sh`
 
 ### Vagrant Smoke tests
 - CentOS
 ```
 $ cd vagrant/centos; vagrant destroy && vagrant up
 $ vagrant ssh master
-$ sudo K8S_VERSION=0.20.2 /vagrant/test/master.sh
+$ sudo K8S_VERSION=1.1.2 /vagrant/test/master.sh
 $ vagrant ssh node
-$ sudo K8S_VERSION=0.20.2 /vagrant/test/node.sh
+$ sudo K8S_VERSION=1.1.2 /vagrant/test/node.sh
 ```
 
--Ubuntu
+- Ubuntu
 ```
 # Trusty
 $ cd vagrant/ubuntu/trusty; vagrant destroy && vagrant up
 $ vagrant ssh master
-$ sudo K8S_VERSION=0.20.2 /vagrant/test/master.sh
+$ sudo K8S_VERSION=1.1.2 /vagrant/test/master.sh
 $ vagrant ssh node
-$ sudo K8S_VERSION=0.20.2 /vagrant/test/node.sh
+$ sudo K8S_VERSION=1.1.2 /vagrant/test/node.sh
 
-#Vivid
+# Vivid
 $ cd vagrant/ubuntu/vivid; vagrant destroy && vagrant up
 $ vagrant ssh master
-$ sudo K8S_VERSION=0.20.2 /vagrant/test/master.sh
+$ sudo K8S_VERSION=1.1.2 /vagrant/test/master.sh
 $ vagrant ssh node
-$ sudo K8S_VERSION=0.20.2 /vagrant/test/node.sh
+$ sudo K8S_VERSION=1.1.2 /vagrant/test/node.sh
 ```
 
-## Requirements
+## Development Requirements
 
 * ruby
 * prerequisites:

--- a/build_etcd.sh
+++ b/build_etcd.sh
@@ -6,10 +6,21 @@
     # --deb-default FILEPATH        (deb only) Add FILEPATH as /etc/default configuration
     # --deb-upstart FILEPATH        (deb only) Add FILEPATH as an upstart script
 
+ETCD_VERSION=2.2.2
+
+rm -rf etcd/source
+mkdir etcd/source
+rm -f etcd/builds/etcd-$ETCD_VERSION-1.x86_64.rpm
+rm -f etcd/builds/etcd-$ETCD_VERSION-1.x86_64.rpm
+rm -f etcd/builds/etcd-$ETCD_VERSION-1.x86_64.rpm
+rm -f etcd/builds/etcd-$ETCD_VERSION-1.x86_64.rpm
+
+
+curl -L  https://github.com/coreos/etcd/releases/download/v$ETCD_VERSION/etcd-v$ETCD_VERSION-linux-amd64.tar.gz | tar xvz -C etcd/source --strip-components 1
 
 fpm -s dir -n "etcd" \
 -p etcd/builds \
--C ./etcd -v 2.0.11 \
+-C ./etcd -v "$ETCD_VERSION" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \
@@ -22,14 +33,14 @@ fpm -s dir -n "etcd" \
 --maintainer "Kismatic, Inc. <info@kismatic.com>" \
 --vendor "Kismatic, Inc." \
 --description "Etcd binaries and services" \
-source/etcd/etcd=/usr/bin/etcd \
-source/etcd/etcdctl=/usr/bin/etcdctl
+source/etcd=/usr/bin/etcd \
+source/etcdctl=/usr/bin/etcdctl
 
 
-# systemd version - add a .1 to the version
+# systemd version - add a .0 to the version
 fpm -s dir -n "etcd" \
 -p etcd/builds/systemd \
--C ./etcd -v 2.0.11.1 \
+-C ./etcd -v "$ETCD_VERSION.0" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \
@@ -42,8 +53,8 @@ fpm -s dir -n "etcd" \
 --maintainer "Kismatic, Inc. <info@kismatic.com>" \
 --vendor "Kismatic, Inc." \
 --description "Etcd binaries and services" \
-source/etcd/etcd=/usr/bin/etcd \
-source/etcd/etcdctl=/usr/bin/etcdctl \
+source/etcd=/usr/bin/etcd \
+source/etcdctl=/usr/bin/etcdctl \
 services/systemd/etcd.service=/lib/systemd/system/etcd.service \
 config/systemd/etcd.conf=/etc/etcd/etcd.conf
 
@@ -53,7 +64,7 @@ config/systemd/etcd.conf=/etc/etcd/etcd.conf
 
 fpm -s dir -n "etcd" \
 -p etcd/builds \
--C ./etcd -v 2.0.11 \
+-C ./etcd -v "$ETCD_VERSION" \
 -t rpm --rpm-os linux \
 -a x86_64 \
 --after-install etcd/scripts/rpm/after-install.sh \
@@ -65,7 +76,7 @@ fpm -s dir -n "etcd" \
 --maintainer "Kismatic, Inc. <info@kismatic.com>" \
 --vendor "Kismatic, Inc." \
 --description "Etcd binaries and services" \
-source/etcd/etcd=/usr/bin/etcd \
-source/etcd/etcdctl=/usr/bin/etcdctl \
+source/etcd=/usr/bin/etcd \
+source/etcdctl=/usr/bin/etcdctl \
 services/systemd/etcd.service=/lib/systemd/system/etcd.service \
 config/systemd/etcd.conf=/etc/etcd/etcd.conf

--- a/build_etcd.sh
+++ b/build_etcd.sh
@@ -40,7 +40,7 @@ source/etcdctl=/usr/bin/etcdctl
 # systemd version - add a .0 to the version
 fpm -s dir -n "etcd" \
 -p etcd/builds/systemd \
--C ./etcd -v "$ETCD_VERSION.0" \
+-C ./etcd -v "$ETCD_VERSION~systemd" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \

--- a/build_kubernetes.sh
+++ b/build_kubernetes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-K8S_VERSION=${K8S_VERSION:-0.20.2}
+K8S_VERSION=${K8S_VERSION:-1.1.2}
 rm -rf kubernetes/source/kubernetes/v$K8S_VERSION
 rm -f kubernetes/master/kubernetes-master-$K8S_VERSION-1.x86_64.rpm
 rm -f kubernetes/master/kubernetes-node-$K8S_VERSION-1.x86_64.rpm
@@ -53,13 +53,12 @@ fpm -s dir -n "kubernetes-master" \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubectl=/usr/bin/kubectl \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubelet=/usr/bin/kubelet \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/hyperkube=/usr/bin/hyperkube \
-../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubernetes=/usr/bin/kubernetes \
 etc/kubernetes/manifests
 
 # systemd version
 fpm -s dir -n "kubernetes-master" \
 -p kubernetes/builds/systemd \
--C ./kubernetes/master -v "$K8S_VERSION.0" \
+-C ./kubernetes/master -v "$K8S_VERSION~systemd" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \
@@ -78,7 +77,6 @@ fpm -s dir -n "kubernetes-master" \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubectl=/usr/bin/kubectl \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubelet=/usr/bin/kubelet \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/hyperkube=/usr/bin/hyperkube \
-../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubernetes=/usr/bin/kubernetes \
 services/systemd/kube-apiserver.service=/lib/systemd/system/kube-apiserver.service \
 services/systemd/kube-controller-manager.service=/lib/systemd/system/kube-controller-manager.service \
 services/systemd/kube-scheduler.service=/lib/systemd/system/kube-scheduler.service \
@@ -89,9 +87,6 @@ etc/kubernetes/master/config.conf \
 etc/kubernetes/master/controller-manager.conf \
 etc/kubernetes/master/scheduler.conf \
 etc/kubernetes/manifests
-
-mv kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION"_amd64.deb kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION"_amd64~systemd.deb
-rm kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION"_amd64.deb
 
 
 # post launch script for addons
@@ -137,7 +132,7 @@ etc/kubernetes/manifests
 # systemd version
 fpm -s dir -n "kubernetes-node" \
 -p kubernetes/builds/systemd \
--C ./kubernetes/node -v "$K8S_VERSION.0" \
+-C ./kubernetes/node -v "$K8S_VERSION~systemd" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \
@@ -186,7 +181,6 @@ fpm -s dir -n "kubernetes-master" \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubectl=/usr/bin/kubectl \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubelet=/usr/bin/kubelet \
 ../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/hyperkube=/usr/bin/hyperkube \
-../source/kubernetes/v$K8S_VERSION/kubernetes/server/bin/kubernetes=/usr/bin/kubernetes \
 services/systemd/kube-apiserver.service=/lib/systemd/system/kube-apiserver.service \
 services/systemd/kube-controller-manager.service=/lib/systemd/system/kube-controller-manager.service \
 services/systemd/kube-scheduler.service=/lib/systemd/system/kube-scheduler.service \

--- a/build_kubernetes.sh
+++ b/build_kubernetes.sh
@@ -59,7 +59,7 @@ etc/kubernetes/manifests
 # systemd version
 fpm -s dir -n "kubernetes-master" \
 -p kubernetes/builds/systemd \
--C ./kubernetes/master -v "$K8S_VERSION" \
+-C ./kubernetes/master -v "$K8S_VERSION.0" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \
@@ -137,7 +137,7 @@ etc/kubernetes/manifests
 # systemd version
 fpm -s dir -n "kubernetes-node" \
 -p kubernetes/builds/systemd \
--C ./kubernetes/node -v "$K8S_VERSION" \
+-C ./kubernetes/node -v "$K8S_VERSION.0" \
 -t deb \
 -a amd64 \
 -d "dpkg (>= 1.17)" \

--- a/kubernetes/master/etc/kubernetes/master/apiserver.conf
+++ b/kubernetes/master/etc/kubernetes/master/apiserver.conf
@@ -5,25 +5,22 @@
 #
 
 # The address on the local server to listen to.
-KUBE_API_ADDRESS="--insecure_bind_address=0.0.0.0"
+KUBE_API_ADDRESS="--insecure-bind-address=0.0.0.0"
 
 # The port on the local server to listen on.
-# KUBE_API_PORT="--insecure-port=8080"
+# KUBE_API_PORT="--port=8080"
 
 # Port minions listen on
-# KUBELET_PORT="--kubelet_port=10250"
+# KUBELET_PORT="--kubelet-port=10250"
 
 # Comma separated list of nodes in the etcd cluster
-KUBE_ETCD_SERVERS="--etcd_servers=http://127.0.0.1:4001"
+KUBE_ETCD_SERVERS="--etcd-servers=http://127.0.0.1:2379"
 
 # Address range to use for services
 KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission_control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
-
-# service account key file
-KUBE_SERVICE_ACCOUNT="--service_account_key_file=/var/kubernetes/kube-serviceaccount.key"
+KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
 
 # Add your own!
-KUBE_API_ARGS="--runtime_config=api/v1beta3 --cluster_name=kubernetes"
+KUBE_API_ARGS=""

--- a/kubernetes/master/etc/kubernetes/master/apiserver.conf
+++ b/kubernetes/master/etc/kubernetes/master/apiserver.conf
@@ -22,5 +22,7 @@ KUBE_SERVICE_ADDRESSES="--service-cluster-ip-range=10.254.0.0/16"
 # default admission control policies
 KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota"
 
+KUBE_SERVICE_ACCOUNT=""
+
 # Add your own!
 KUBE_API_ARGS=""

--- a/kubernetes/master/etc/kubernetes/master/controller-manager.conf
+++ b/kubernetes/master/etc/kubernetes/master/controller-manager.conf
@@ -1,7 +1,4 @@
 ###
 # The following values are used to configure the kubernetes controller-manager
 
-# defaults from config and apiserver should be adequate
-
-# Add you own!
-KUBE_CONTROLLER_MANAGER_ARGS="--master=127.0.0.1:8080 --service_account_private_key_file=/var/kubernetes/kube-serviceaccount.key --cluster_name=kubernetes --cluster-cidr=10.244.0.0/16"
+KUBE_CONTROLLER_MANAGER_ARGS="--cluster_name=kubernetes --cluster-cidr=10.244.0.0/16 --service-account-private-key-file=/srv/kubernetes/kube-serviceaccount.key"

--- a/kubernetes/master/initd_config/kube-apiserver
+++ b/kubernetes/master/initd_config/kube-apiserver
@@ -1,15 +1,14 @@
 # TODO: generate and distribute tokens for other cloud providers.
 DAEMON_ARGS="$DAEMON_ARGS
 --insecure_bind_address=0.0.0.0 \
---etcd_servers=http://127.0.0.1:4001 \
+--etcd_servers=http://127.0.0.1:2379 \
 --service-cluster-ip-range=10.254.0.0/16 \
 --v=2 \
---insecure-port=8080 \
+--port=8080 \
 --allow_privileged=False \
 --kubelet_port=10250 \
---runtime_config=api/v1beta3 \
---admission_control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
---service_account_key_file=/var/kubernetes/kube-serviceaccount.key \
+--admission_control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
+--service_account_key_file=/srv/kubernetes/kube-serviceaccount.key \
 --cluster_name=kubernetes"
 
 #--tls_cert_file=/srv/kubernetes/server.cert --tls_private_key_file=/srv/kubernetes/server.key --secure_port=6443 --token_auth_file=/srv/kubernetes/known_tokens.csv

--- a/kubernetes/master/scripts/deb/after-install.sh
+++ b/kubernetes/master/scripts/deb/after-install.sh
@@ -10,7 +10,6 @@
 
         chmod +x /usr/bin/kubectl
         chmod +x /usr/bin/hyperkube
-        chmod +x /usr/bin/kubernetes
 
         update-rc.d kube-apiserver defaults >/dev/null 2>&1 || :
         update-rc.d kube-scheduler defaults >/dev/null 2>&1 || :

--- a/kubernetes/master/scripts/deb/before-install.sh
+++ b/kubernetes/master/scripts/deb/before-install.sh
@@ -1,39 +1,17 @@
 #!/bin/bash
 
-getent group kube-apiserver >/dev/null || groupadd -r kube-apiserver
-getent passwd kube-apiserver >/dev/null || useradd -r -g kube-apiserver -d /var/kube-apiserver -s /sbin/nologin \
-        -c "Kubernetes apiserver user" kube-apiserver
-
-getent group kube-controller-manager >/dev/null || groupadd -r kube-controller-manager
-getent passwd kube-controller-manager >/dev/null || useradd -r -g kube-controller-manager -d /var/kube-controller-manager -s /sbin/nologin \
-        -c "Kubernetes controller-manager user" kube-controller-manager
-
-getent group kube-scheduler >/dev/null || groupadd -r kube-scheduler
-getent passwd kube-scheduler >/dev/null || useradd -r -g kube-scheduler -d /var/kube-scheduler -s /sbin/nologin \
-        -c "Kubernetes scheduler user" kube-scheduler
-
 getent group kube-cert >/dev/null || groupadd -r kube-cert
-
-mkdir -p -m 755 /var/kube-apiserver
-chown -R kube-apiserver /var/kube-apiserver
-chgrp -R kube-apiserver /var/kube-apiserver
-
-mkdir -p -m 755 /var/kube-controller-manager
-chown -R kube-controller-manager /var/kube-controller-manager
-chgrp -R kube-controller-manager /var/kube-controller-manager
-
-mkdir -p -m 755 /var/kube-scheduler
-chown -R kube-scheduler /var/kube-scheduler
-chgrp -R kube-scheduler /var/kube-scheduler
-
 mkdir -p -m 755 /var/run/kubernetes
-chown -R kube-apiserver /var/run/kubernetes
-chgrp -R kube-apiserver /var/run/kubernetes
 
-mkdir -p -m 755 /var/lib/kubelet
+getent group kube >/dev/null || groupadd -r kube
+getent passwd kube >/dev/null || useradd -r -g kube -d /var/run/kubernetes -s /sbin/nologin \
+        -c "Kubernetes user" kube
+
+chown -R kube /var/run/kubernetes
+chgrp -R kube /var/run/kubernetes
 
 
-SERVICE_ACCOUNT_KEY="/var/kubernetes/kube-serviceaccount.key"
+SERVICE_ACCOUNT_KEY="/srv/kubernetes/kube-serviceaccount.key"
 # Generate ServiceAccount key if needed
 if [[ ! -f "${SERVICE_ACCOUNT_KEY}" ]]; then
   mkdir -p "$(dirname ${SERVICE_ACCOUNT_KEY})"

--- a/kubernetes/master/scripts/deb/systemd/after-install.sh
+++ b/kubernetes/master/scripts/deb/systemd/after-install.sh
@@ -7,7 +7,6 @@
 
         chmod +x /usr/bin/kubectl
         chmod +x /usr/bin/hyperkube
-        chmod +x /usr/bin/kubernetes
 
         # Initial installation
         systemctl preset kube-apiserver kube-scheduler kube-controller-manager >/dev/null 2>&1 || :

--- a/kubernetes/master/scripts/deb/systemd/before-install.sh
+++ b/kubernetes/master/scripts/deb/systemd/before-install.sh
@@ -1,38 +1,15 @@
 #!/bin/bash
-
-getent group kube-apiserver >/dev/null || groupadd -r kube-apiserver
-getent passwd kube-apiserver >/dev/null || useradd -r -g kube-apiserver -d /var/kube-apiserver -s /sbin/nologin \
-        -c "Kubernetes apiserver user" kube-apiserver
-
-getent group kube-controller-manager >/dev/null || groupadd -r kube-controller-manager
-getent passwd kube-controller-manager >/dev/null || useradd -r -g kube-controller-manager -d /var/kube-controller-manager -s /sbin/nologin \
-        -c "Kubernetes controller-manager user" kube-controller-manager
-
-getent group kube-scheduler >/dev/null || groupadd -r kube-scheduler
-getent passwd kube-scheduler >/dev/null || useradd -r -g kube-scheduler -d /var/kube-scheduler -s /sbin/nologin \
-        -c "Kubernetes scheduler user" kube-scheduler
-
 getent group kube-cert >/dev/null || groupadd -r kube-cert
-
-mkdir -p -m 755 /var/kube-apiserver
-chown -R kube-apiserver /var/kube-apiserver
-chgrp -R kube-apiserver /var/kube-apiserver
-
-mkdir -p -m 755 /var/kube-controller-manager
-chown -R kube-controller-manager /var/kube-controller-manager
-chgrp -R kube-controller-manager /var/kube-controller-manager
-
-mkdir -p -m 755 /var/kube-scheduler
-chown -R kube-scheduler /var/kube-scheduler
-chgrp -R kube-scheduler /var/kube-scheduler
-
 mkdir -p -m 755 /var/run/kubernetes
-chown -R kube-apiserver /var/run/kubernetes
-chgrp -R kube-apiserver /var/run/kubernetes
 
-mkdir -p -m 755 /var/lib/kubelet
+getent group kube >/dev/null || groupadd -r kube
+getent passwd kube >/dev/null || useradd -r -g kube -d /var/run/kubernetes -s /sbin/nologin \
+        -c "Kubernetes user" kube
 
-SERVICE_ACCOUNT_KEY="/var/kubernetes/kube-serviceaccount.key"
+chown -R kube /var/run/kubernetes
+chgrp -R kube /var/run/kubernetes
+
+SERVICE_ACCOUNT_KEY="/srv/kubernetes/kube-serviceaccount.key"
 # Generate ServiceAccount key if needed
 if [ ! -f "${SERVICE_ACCOUNT_KEY}" ]; then
   mkdir -p "$(dirname ${SERVICE_ACCOUNT_KEY})"

--- a/kubernetes/master/scripts/rpm/after-install.sh
+++ b/kubernetes/master/scripts/rpm/after-install.sh
@@ -8,7 +8,6 @@ if [ $1 -eq 1 ] ; then
 
         chmod +x /usr/bin/kubectl
         chmod +x /usr/bin/hyperkube
-        chmod +x /usr/bin/kubernetes
 
         # Initial installation
         systemctl preset kube-apiserver kube-scheduler kube-controller-manager >/dev/null 2>&1 || :

--- a/kubernetes/master/scripts/rpm/before-install.sh
+++ b/kubernetes/master/scripts/rpm/before-install.sh
@@ -1,38 +1,17 @@
 #!/bin/bash
 
-getent group kube-apiserver >/dev/null || groupadd -r kube-apiserver
-getent passwd kube-apiserver >/dev/null || useradd -r -g kube-apiserver -d /var/kube-apiserver -s /sbin/nologin \
-        -c "Kubernetes apiserver user" kube-apiserver
-
-getent group kube-controller-manager >/dev/null || groupadd -r kube-controller-manager
-getent passwd kube-controller-manager >/dev/null || useradd -r -g kube-controller-manager -d /var/kube-controller-manager -s /sbin/nologin \
-        -c "Kubernetes controller-manager user" kube-controller-manager
-
-getent group kube-scheduler >/dev/null || groupadd -r kube-scheduler
-getent passwd kube-scheduler >/dev/null || useradd -r -g kube-scheduler -d /var/kube-scheduler -s /sbin/nologin \
-        -c "Kubernetes scheduler user" kube-scheduler
-
 getent group kube-cert >/dev/null || groupadd -r kube-cert
-
-mkdir -p -m 755 /var/kube-apiserver
-chown -R kube-apiserver /var/kube-apiserver
-chgrp -R kube-apiserver /var/kube-apiserver
-
-mkdir -p -m 755 /var/kube-controller-manager
-chown -R kube-controller-manager /var/kube-controller-manager
-chgrp -R kube-controller-manager /var/kube-controller-manager
-
-mkdir -p -m 755 /var/kube-scheduler
-chown -R kube-scheduler /var/kube-scheduler
-chgrp -R kube-scheduler /var/kube-scheduler
-
 mkdir -p -m 755 /var/run/kubernetes
-chown -R kube-apiserver /var/run/kubernetes
-chgrp -R kube-apiserver /var/run/kubernetes
 
-mkdir -p -m 755 /var/lib/kubelet
+getent group kube >/dev/null || groupadd -r kube
+getent passwd kube >/dev/null || useradd -r -g kube -d /var/run/kubernetes -s /sbin/nologin \
+        -c "Kubernetes user" kube
 
-SERVICE_ACCOUNT_KEY="/var/kubernetes/kube-serviceaccount.key"
+chown -R kube /var/run/kubernetes
+chgrp -R kube /var/run/kubernetes
+
+
+SERVICE_ACCOUNT_KEY="/srv/kubernetes/kube-serviceaccount.key"
 # Generate ServiceAccount key if needed
 if [[ ! -f "${SERVICE_ACCOUNT_KEY}" ]]; then
   mkdir -p "$(dirname ${SERVICE_ACCOUNT_KEY})"

--- a/kubernetes/master/services/initd/kube-apiserver
+++ b/kubernetes/master/services/initd/kube-apiserver
@@ -20,7 +20,7 @@ DAEMON=/usr/bin/kube-apiserver
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-DAEMON_USER=kube-apiserver
+DAEMON_USER=kube
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0

--- a/kubernetes/master/services/initd/kube-controller-manager
+++ b/kubernetes/master/services/initd/kube-controller-manager
@@ -22,7 +22,7 @@ DAEMON_ARGS=""
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-DAEMON_USER=kube-controller-manager
+DAEMON_USER=kube
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0

--- a/kubernetes/master/services/initd/kube-scheduler
+++ b/kubernetes/master/services/initd/kube-scheduler
@@ -22,7 +22,7 @@ DAEMON_ARGS=" --master=127.0.0.1:8080"
 DAEMON_LOG_FILE=/var/log/$NAME.log
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
-DAEMON_USER=kube-scheduler
+DAEMON_USER=kube
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0

--- a/kubernetes/master/services/systemd/kube-apiserver.service
+++ b/kubernetes/master/services/systemd/kube-apiserver.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=-/etc/kubernetes/master/config.conf
 EnvironmentFile=-/etc/kubernetes/master/apiserver.conf
-User=kube-apiserver
+User=kube
 ExecStart=/usr/bin/kube-apiserver \
       $KUBE_LOGTOSTDERR \
       $KUBE_LOG_LEVEL \

--- a/kubernetes/master/services/systemd/kube-controller-manager.service
+++ b/kubernetes/master/services/systemd/kube-controller-manager.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=-/etc/kubernetes/master/config.conf
 EnvironmentFile=-/etc/kubernetes/master/controller-manager.conf
-User=kube-controller-manager
+User=kube
 ExecStart=/usr/bin/kube-controller-manager \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \

--- a/kubernetes/master/services/systemd/kube-scheduler.service
+++ b/kubernetes/master/services/systemd/kube-scheduler.service
@@ -5,7 +5,7 @@ Documentation=https://github.com/GoogleCloudPlatform/kubernetes
 [Service]
 EnvironmentFile=-/etc/kubernetes/master/config.conf
 EnvironmentFile=-/etc/kubernetes/master/scheduler.conf
-User=kube-scheduler
+User=kube
 ExecStart=/usr/bin/kube-scheduler \
 	    $KUBE_LOGTOSTDERR \
 	    $KUBE_LOG_LEVEL \

--- a/vagrant/ubuntu/vivid/test/master.sh
+++ b/vagrant/ubuntu/vivid/test/master.sh
@@ -3,7 +3,7 @@ echo "Installing Docker"
 # echo `wget -qO- https://get.docker.com/ | sh`
 
 echo "Installing etcd locally"
-echo `dpkg -i /kubernetes/etcd/builds/systemd/etcd_2.0.11.0_amd64.deb`
+echo `dpkg -i /kubernetes/etcd/builds/systemd/etcd_2.2.2~systemd_amd64.deb`
 
 sleep 1
 echo "service etcd start..."
@@ -12,7 +12,7 @@ echo `service etcd start`
 echo "Installing master $K8S_VERSION locally"
 dpkg -P kubernetes-master
 sleep 1
-echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION".0_amd64.deb`
+echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION"~systemd_amd64.deb`
 
 apt-get clean
 

--- a/vagrant/ubuntu/vivid/test/master.sh
+++ b/vagrant/ubuntu/vivid/test/master.sh
@@ -3,7 +3,7 @@ echo "Installing Docker"
 # echo `wget -qO- https://get.docker.com/ | sh`
 
 echo "Installing etcd locally"
-echo `dpkg -i /kubernetes/etcd/builds/systemd/etcd_2.0.11.1_amd64.deb`
+echo `dpkg -i /kubernetes/etcd/builds/systemd/etcd_2.0.11.0_amd64.deb`
 
 sleep 1
 echo "service etcd start..."
@@ -12,7 +12,7 @@ echo `service etcd start`
 echo "Installing master $K8S_VERSION locally"
 dpkg -P kubernetes-master
 sleep 1
-echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION".1_amd64.deb`
+echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-master_"$K8S_VERSION".0_amd64.deb`
 
 apt-get clean
 

--- a/vagrant/ubuntu/vivid/test/node.sh
+++ b/vagrant/ubuntu/vivid/test/node.sh
@@ -4,7 +4,7 @@ echo `wget -qO- https://get.docker.com/ | sh`
 
 echo "Installing node $K8S_VERSION locally"
 dpkg -P kubernetes-node
-echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-node_"$K8S_VERSION".1_amd64.deb`
+echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-node_"$K8S_VERSION".0_amd64.deb`
 
 apt-get clean
 sleep 3

--- a/vagrant/ubuntu/vivid/test/node.sh
+++ b/vagrant/ubuntu/vivid/test/node.sh
@@ -4,7 +4,7 @@ echo `wget -qO- https://get.docker.com/ | sh`
 
 echo "Installing node $K8S_VERSION locally"
 dpkg -P kubernetes-node
-echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-node_"$K8S_VERSION".0_amd64.deb`
+echo `dpkg -i /kubernetes/kubernetes/builds/systemd/kubernetes-node_"$K8S_VERSION"~systemd_amd64.deb`
 
 apt-get clean
 sleep 3


### PR DESCRIPTION
Updated Kubernetes to v1.1.2 along with some minor improvements:
- Added cert generation instructions to readme
- Updated k8s base configuration files and remove obsolete kubernetes binary
- Updated etcd build script for v2.2.1
- Switched services user to `kube`
- Changed k8s versioning scheme to allow for debian/ubuntu systemd and initd packages to co-exist on a single repo server
